### PR TITLE
allow dns across accounts

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,4 +1,6 @@
 data "aws_route53_zone" "zone" {
   name         = "${var.hosted_zone_name}"
   private_zone = "false"
+
+  provider = "aws.dns"
 }

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,8 @@ resource "aws_route53_record" "this" {
   zone_id = "${data.aws_route53_zone.zone.id}"
   records = ["${aws_acm_certificate.this.domain_validation_options.0.resource_record_value}"]
   ttl     = 60
+
+  provider = "aws.dns"
 }
 
 resource "aws_acm_certificate_validation" "dns_validation" {

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,4 @@
+/* This is a provider used for the DNS record creation as we host zones accross multiple accounts */
+provider "aws" {
+  alias = "dns"
+}


### PR DESCRIPTION
We host zones across multiple accounts so this module needed to be extended to be able to handle that fact.